### PR TITLE
fix: remove text-overflow in input elements

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -108,8 +108,6 @@ select {
     padding: 0 2.5em 0 .5em;
     border-radius: 4px;
     border: 0;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     font-family: var(--font-family);
     font-size: 1em;
     line-height: initial;
@@ -145,7 +143,6 @@ textarea {
     border: 1px solid var(--border-color);
     background-color: var(--input-background);
     color: var(--input-color);
-    text-overflow: ellipsis;
     font-family: var(--font-family);
     font-size: var(--font-size);
     line-height: 1.35;
@@ -213,8 +210,6 @@ input[type="password"],
 input[type="email"],
 input[type="number"] {
     width: 100%;
-    text-overflow: ellipsis;
-    overflow: hidden;
     box-shadow: none;
 }
 

--- a/stylesheets/components/input.css
+++ b/stylesheets/components/input.css
@@ -3,8 +3,6 @@
     box-sizing: border-box;
     height: var(--control-height);
     align-items: center;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     border-radius: var(--border-radius);
     border: 1px solid var(--border-color);
     background-color: var(--input-background);


### PR DESCRIPTION
This seems to be causing unexpected quirks, e.g. https://ubio.slack.com/archives/C0B6DFTTQ/p1598798997000500 and the general consensus that it is best to leave the browser defaults. That being said, I am not the author, so an additional pair of eyes will come in handy.